### PR TITLE
Add a new 'passwordfd' command and '--passwordfd' option

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Version 1.8.27:
+- A new command 'passwordfd' with a corresponding '--passwordfd' option
+  allows to read the password from a file descriptor inherited from
+  a parent process.
+
 Version 1.8.26:
 - Add support for SCRAM-SHA-256-PLUS and SCRAM-SHA-1-PLUS authentication, and
   prefer SCRAM methods over the PLAIN method because of their superior

--- a/doc/msmtp.1
+++ b/doc/msmtp.1
@@ -110,6 +110,8 @@ See the \fBauth\fP command.
 Set or unset the user name for authentication. See the \fBuser\fP command.
 .IP "\-\-passwordeval=[\fIcmd\fP]"
 Evaluate password for authentication. See the \fBpasswordeval\fP command.
+.IP "\-\-passwordfd=[\fInumber\fP]"
+Read password from a file descriptor. See the \fBpasswordfd\fP command.
 .IP "\-\-tls[=(\fIon\fP|\fIoff\fP)]"
 Enable or disable TLS/SSL. See the \fBtls\fP command.
 .IP "\-\-tls\-starttls[=(\fIon\fP|\fIoff\fP)]"
@@ -381,13 +383,15 @@ joe.smith with your user name.
 2. Store the password in an encrypted files, and use \fBpasswordeval\fP
 to specify a command to decrypt that file, e.g. using GnuPG. See EXAMPLES.
 .br
-3. Store the password in the configuration file using the \fBpassword\fP command.
+3. Pass the password via a file descriptor inherited from a parent process.
+.br
+4. Store the password in the configuration file using the \fBpassword\fP command.
 (Usually it is not considered a good idea to store passwords in cleartext files.
 If you do it anyway, you must make sure that the file can only be read by yourself.)
 .br
-4. Store the password in ~/.netrc. This method is probably obsolete.
+5. Store the password in ~/.netrc. This method is probably obsolete.
 .br
-5. Type the password into the terminal when it is required.
+6. Type the password into the terminal when it is required.
 .br
 It is recommended to use method 1 or 2.
 .br
@@ -422,9 +426,9 @@ password information and have to be chosen manually: \fIoauthbearer\fP or its
 predecessor \fIxoauth2\fP (an OAuth2
 token from the mail provider is used as the password.
 See the documentation of your mail provider for details on how to get this
-token. The \fBpasswordeval\fP command can be used to pass the regularly changing
-tokens into msmtp from a script or an environment variable),
-\fIexternal\fP (the
+token. The \fBpasswordeval\fP or \fBpasswordfd\fP command can be used
+to pass the regularly changing tokens into msmtp from a script or an
+environment variable), \fIexternal\fP (the
 authentication happens outside of the protocol, typically by sending a TLS
 client certificate, and the method merely confirms that this authentication
 succeeded), and \fIgssapi\fP (the Kerberos framework takes care of secure
@@ -437,8 +441,9 @@ methods are supported.
 Set the user name for authentication. An empty argument unsets the user name.
 .IP "password \fIsecret\fP"
 Set the password for authentication. An empty argument unsets the password.
-Consider using the \fBpasswordeval\fP command or a key ring instead of this
-command, to avoid storing cleartext passwords in the configuration file.
+Consider using the \fBpasswordeval\fP or \fBpasswordfd\fP command or a
+key ring instead of this command, to avoid storing cleartext passwords
+in the configuration file.
 .IP "passwordeval [\fIcmd\fP]"
 Set the password for authentication to the output (stdout) of the command
 \fIcmd\fP.
@@ -447,6 +452,9 @@ rings, and thus to avoid storing cleartext passwords.
 .br
 The \fIcmd\fP command must not mess with standard input; if in doubt, append
 \fI< /dev/null\fP.
+.IP "passwordfd [\fInumber\fP]"
+Read the password from the file descriptor \fInumber\fP inherited from
+a parent process.
 .IP "ntlmdomain [\fIdomain\fP]"
 Set a domain for the \fBntlm\fP authentication method. This is obsolete.
 .IP "tls [(\fIon\fP|\fIoff\fP)]"
@@ -510,7 +518,7 @@ device by specifying GnuTLS device URIs in \fBtls_cert_file\fP and
 \fBtls_key_file\fP. You can find the correct URIs using \fBp11tool
 \-\-list-privkeys \-\-login\fP (p11tool is bundled with GnuTLS). If your device
 requires a PIN to access the data, you can specify that using one of the
-password mechanisms (e.g. \fBpasswordeval\fP, \fBpassword\fP). 
+password mechanisms (e.g. \fBpasswordeval\fP, \fBpasswordfd\fP, \fBpassword\fP).
 .IP "tls_starttls [(\fIon\fP|\fIoff\fP)]"
 Choose the TLS variant: start TLS from within the session (\fIon\fP, default),
 or tunnel the session through TLS (\fIoff\fP).

--- a/doc/msmtp.texi
+++ b/doc/msmtp.texi
@@ -277,6 +277,10 @@ rings, and thus to avoid storing cleartext passwords.@*
 The @var{cmd} command must not mess with standard input; if in doubt, append
 @code{< /dev/null}.@*
 @xref{Authentication}.
+@anchor{passwordfd}
+@item passwordfd [@var{number}]
+Read the password from the file descriptor @var{number} inherited from
+a parent process.
 @anchor{ntlmdomain}
 @item ntlmdomain [@var{ntlmdomain}]
 @cmindex ntlmdomain

--- a/src/conf.c
+++ b/src/conf.c
@@ -8,6 +8,7 @@
  * Martin Lambers <marlam@marlam.de>
  * Martin Stenberg <martin@gnutiken.se> (passwordeval support)
  * Scott Shumate <sshumate@austin.rr.com> (aliases support)
+ * Łukasz stelmach <stlman@poczta.fm> (passwordfd support)
  *
  *   This program is free software; you can redistribute it and/or modify
  *   it under the terms of the GNU General Public License as published by
@@ -83,6 +84,7 @@ account_t *account_new(const char *conffile, const char *id)
     a->username = NULL;
     a->password = NULL;
     a->passwordeval = NULL;
+    a->passwordfd = -1;
     a->ntlmdomain = NULL;
     a->tls = 0;
     a->tls_nostarttls = 0;
@@ -146,6 +148,7 @@ account_t *account_copy(account_t *acc)
         a->username = acc->username ? xstrdup(acc->username) : NULL;
         a->password = acc->password ? xstrdup(acc->password) : NULL;
         a->passwordeval = acc->passwordeval ? xstrdup(acc->passwordeval) : NULL;
+        a->passwordfd = acc->passwordfd;
         a->ntlmdomain = acc->ntlmdomain ? xstrdup(acc->ntlmdomain) : NULL;
         a->tls = acc->tls;
         a->tls_nostarttls = acc->tls_nostarttls;
@@ -652,6 +655,10 @@ void override_account(account_t *acc1, account_t *acc2)
         free(acc1->passwordeval);
         acc1->passwordeval =
             acc2->passwordeval ? xstrdup(acc2->passwordeval) : NULL;
+    }
+    if (acc2->mask & ACC_PASSWORDFD)
+    {
+        acc1->passwordfd = acc2->passwordfd;
     }
     if (acc2->mask & ACC_NTLMDOMAIN)
     {
@@ -1530,6 +1537,11 @@ int read_conffile(const char *conffile, FILE *f, list_t **acc_list,
             acc->mask |= ACC_PASSWORDEVAL;
             free(acc->passwordeval);
             acc->passwordeval = (*arg == '\0') ? NULL : xstrdup(arg);
+        }
+        else if (strcmp(cmd, "passwordfd") == 0)
+        {
+            acc->mask |= ACC_PASSWORDFD;
+            acc->passwordfd = (*arg == '\0') ? -1 : strtol(arg, NULL, 10);
         }
         else if (strcmp(cmd, "ntlmdomain") == 0)
         {

--- a/src/conf.h
+++ b/src/conf.h
@@ -88,6 +88,7 @@
 #define ACC_SOCKET                      (1LL << 38LL)
 #define ACC_FROM_FULL_NAME              (1LL << 39LL)
 #define ACC_ALLOW_FROM_OVERRIDE         (1LL << 40LL)
+#define ACC_PASSWORDFD                  (1LL << 41LL)
 
 typedef struct
 {
@@ -117,6 +118,7 @@ typedef struct
     char *username;             /* username for authentication */
     char *password;             /* password for authentication */
     char *passwordeval;         /* command for password evaluation */
+    int passwordfd;             /* file descriptor to read the password from */
     char *ntlmdomain;           /* domain for NTLM authentication */
     /* TLS / SSL */
     int tls;                    /* flag: use TLS? */

--- a/src/password.h
+++ b/src/password.h
@@ -44,4 +44,13 @@ char *password_get(const char *hostname, const char *user,
         int consult_netrc,
         int getpass_only_via_tty);
 
+/*
+ * password_get_fd()
+ *
+ * Reads the password from the file descriptor 'fd' and stores result in
+ * 'buf' (which is allocated).  Returns non-zero if the operation fails,
+ * otherwise zero. On error, *errstr will contain an error string.
+ */
+int password_get_fd(int fd, char **buf, char **errstr);
+
 #endif


### PR DESCRIPTION
This allows receiving the password from a parent process.

The code for reading from the file descriptor is a repuprposed password_eval() function removed in commit e16c5d9 ("remove password_eval() which moved to eval()").