### PR TITLE
increase size of eval buffer for large tokens

### DIFF
--- a/src/eval.c
+++ b/src/eval.c
@@ -41,7 +41,7 @@
  * see eval.h
  */
 
-#define LINEBUFSIZE 501
+#define LINEBUFSIZE 2049
 int eval(const char *arg, char **buf, char **errstr)
 {
     FILE *f;


### PR DESCRIPTION
Authentication tokens for OAuth2 can be much larger than the current 500 byte limit.  Increase the buffer size to 2k to accommodate tokens produced for Microsoft office.com accounts.