### PR TITLE
fix inappropriate notification of incomplete queue

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -348,8 +348,8 @@ send_queued_mail() {   # <-- mail id
 ## run (flush) queue
 ##
 run_queue() {    # <- 'sm' mode      # run queue
-  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ] && [ -z "$1" ]; then
-    dsp '' 'mail queue is empty (nothing to send)' ''
+  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ]; then
+    [ -n "$1" ] || dsp '' 'mail queue is empty (nothing to send)' ''
     return
   fi
 


### PR DESCRIPTION
The variable check was only necessary for additional notification if the queue was flushed, but also showed up if a single message was sent