### PR TITLE
quiet email queue by default

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -55,10 +55,8 @@ shopt -s inherit_errexit
 IFS=$' \n\t'
 PS4='+\t '
 
-if [[ ! -t 0 ]] && [[ -n "$DISPLAY" ]] && command -v notify-send >/dev/null 2>&1; then
-  NOTIFY_SEND=${NOTIFY_SEND:-1}
-else
-  NOTIFY_SEND=${NOTIFY_SEND:-0}
+if [[ -z "$NOTIFY_SEND" ]] && [[ ! -t 0 ]] && [[ -n "$DISPLAY" ]] && command -v notify-send >/dev/null 2>&1; then
+  NOTIFY_SEND=1
 fi
 
 log_later() { LOG_LATER_ARGS=( "$@" ) ; }

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -130,6 +130,7 @@ fi
 ##                       if =n will use netcat (nc) to test for a connection
 ##                       if =s will use bash sockets to test for a connection
 ##   EMAIL_QUEUE_QUIET   if set will cause suppression of messages and 'chatter'
+EMAIL_QUEUE_QUIET=${EMAIL_QUEUE_QUIET:-1}
 ##                         (perhaps useful for some of the emacs mail clients)
 ##
 ## ======================================================================================
@@ -142,7 +143,6 @@ fi
 ##
 #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
 #EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
-#EMAIL_QUEUE_QUIET=t
 ## ======================================================================================
 
 umask 077                            # set secure permissions on created directories and files
@@ -185,7 +185,7 @@ log() {
     shift 2                          # shift opt & its arg off
   fi
 
-  [ -z "$EMAIL_QUEUE_QUIET" ] && dsp "$@"  # display msg to user, as well as logging it
+  [ "$EMAIL_QUEUE_QUIET" = "0" ] && dsp "$@"  # display msg to user, as well as logging it
 
   if [ -n "$MSMTPQ_LOG" ] ; then     # log is defined and in use
     for ARG ; do                     # each msg line out


### PR DESCRIPTION
See https://github.com/marlam/msmtp/commit/32eaad1ffba2b8ebbbe77d2b5ee548343bbd2a40#commitcomment-147723969

> However, there could be an opt-in variable to allow sending a notification for emails being queued. But this intrusive mechanism shouldn't be on by default, as people might be using msmtpq as their default mail handler and this mechanism can be a bit obnoxious.

Ideally, notifications are only shown if sending failed (and the message is queued), but as the code stands its wholesale.