### PR TITLE
Check for SMTPUTF8 capability and include that in MAIL command

### DIFF
--- a/src/msmtp.c
+++ b/src/msmtp.c
@@ -515,6 +515,11 @@ int msmtp_serverinfo(account_t *acc, int debug, list_t **msg, char **errstr)
             printf("    PIPELINING:\n        %s\n", _("Support for command "
                         "grouping for faster transmission"));
         }
+        if (srv.cap.flags & SMTP_CAP_SMTPUTF8)
+        {
+            printf("    SMTPUTF8:\n        %s\n", _("Support for "
+                "Email Address Internationalization (EAI) as defined in RFC 6531"));
+        }
         if (srv.cap.flags & SMTP_CAP_ETRN)
         {
             printf("    ETRN:\n        %s\n", _("Support for RMQS "

--- a/src/smtp.c
+++ b/src/smtp.c
@@ -1705,18 +1705,11 @@ int smtp_send_envelope(smtp_server_t *srv,
             /* send */
             if (!mailfrom_cmd_was_sent)
             {
-                if (dsn_return)
-                {
-                    e = smtp_send_cmd(srv, errstr, "MAIL FROM:<%s> RET=%s",
-                            strcasecmp(envelope_from, "MAILER-DAEMON") == 0
-                            ? "" : envelope_from, dsn_return);
-                }
-                else
-                {
-                    e = smtp_send_cmd(srv, errstr, "MAIL FROM:<%s>",
-                            strcasecmp(envelope_from, "MAILER-DAEMON") == 0
-                            ? "" : envelope_from);
-                }
+                e = smtp_send_cmd(srv, errstr, "MAIL FROM:<%s>%s%s%s",
+                        strcasecmp(envelope_from, "MAILER-DAEMON") == 0
+                        ? "" : envelope_from,
+                        dsn_return ? " RET=" : "", dsn_return ? dsn_return : "",
+                        srv->cap.flags & SMTP_CAP_SMTPUTF8 ? " SMTPUTF8" : "");
                 if (e != SMTP_EOK)
                 {
                     return e;

--- a/src/smtp.c
+++ b/src/smtp.c
@@ -520,6 +520,10 @@ int smtp_init(smtp_server_t *srv, const char *ehlo_domain, list_t **errmsg,
         {
             srv->cap.flags |= SMTP_CAP_ETRN;
         }
+        else if (strncmp(s + 4, "SMTPUTF8", 8) == 0)
+        {
+            srv->cap.flags |= SMTP_CAP_SMTPUTF8;
+        }
     }
 
     list_xfree(ehlo_response, free);

--- a/src/smtp.h
+++ b/src/smtp.h
@@ -77,6 +77,7 @@
 #define SMTP_CAP_AUTH_NTLM               (1 << 16)
 #define SMTP_CAP_AUTH_XOAUTH2            (1 << 17)
 #define SMTP_CAP_ETRN                    (1 << 18)
+#define SMTP_CAP_SMTPUTF8                (1 << 19)
 
 
 /*


### PR DESCRIPTION
[We got to use punycode at least for domain part.](https://github.com/mlt/msmtp/actions/runs/11506920169/job/32031931048#step:10:80) I saw a bunch of RFCs talking about local part and downgrading as well as a proposed use of SMTPUTF8 extension on both sides. What is your take on that?