### PR TITLE
msmtpq - macOS portability

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -85,7 +85,7 @@ bash_has_min_version() {
 
 # see https://git.savannah.gnu.org/gitweb/?p=bash.git;a=blob;f=NEWS;hb=6794b5478f660256a1023712b5fc169196ed0a22#l654
 if bash_has_min_version 4 4 ; then
-    if [ "$POSIXLY_CORRECT" = "y" ]; then
+    if [ "$POSIXLY_CORRECT" == "y" ]; then
         shopt -s inherit_errexit 2>/dev/null
     fi
 fi

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -265,10 +265,10 @@ lock_queue() {        # <-- '-u' to remove lockfile
 ##
 case $(uname | tr '[:upper:]' '[:lower:]') in
   darwin* | *bsd)
-    export PING_TIMEOUT_FLAG=t
+    PING_TIMEOUT_FLAG=t
     ;;
   *)
-    export PING_TIMEOUT_FLAG=w
+    PING_TIMEOUT_FLAG=w
     ;;
 esac
 connect_test() {

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -393,22 +393,10 @@ send_queued_mail() {   # <-- mail id
   fi                                                           # (but allow continuation)
 }
 
-is_queue_dir_empty() {
-    # - "shopt -p" is available as of bash 2.01.1
-    # - "trap ... RETURN" is available as of bash 2.05b
-    # - the return value of shopt must be ignored (the manual says:
-    #   "The return status when listing options is zero if all
-    #   optnames are enabled, non-zero otherwise.")
-    trap "$(shopt -p nullglob || true)" RETURN
-    shopt -s nullglob
-    files=( "$MSMTPQ_Q"/*.mail )
-    (( ${#files[@]} == 0 ))
-}
-
 ## run (flush) queue
 ##
 run_queue() {    # <- 'sm' mode      # run queue
-  if is_queue_dir_empty ; then
+  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ]; then
     [ -n "$1" ] || dsp '' 'mail queue is empty (nothing to send)' ''
     return
   fi
@@ -428,7 +416,7 @@ run_queue() {    # <- 'sm' mode      # run queue
 ## display queue contents
 ##
 display_queue() {      # <-- { 'purge' | 'send' } (op label) ; { 'rec' } (record array of mail ids)
-  if is_queue_dir_empty ; then
+  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ]; then
     if [ -z "$1" ]; then
       dsp '' 'no mail in queue' ''
     else

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -78,7 +78,7 @@ set -o errtrace -o errexit            -o pipefail
 # optionally debug output by supplying TRACE=1
 [[ "${TRACE:-0}" == "1" ]] && set -o xtrace
 
-shopt -s inherit_errexit
+shopt -s inherit_errexit 2>/dev/null || true
 IFS=$' \n\t'
 PS4='+\t '
 
@@ -263,6 +263,14 @@ lock_queue() {        # <-- '-u' to remove lockfile
 ## test whether system is connected
 ## returns t/f (0/1)
 ##
+case $(uname | tr '[:upper:]' '[:lower:]') in
+  darwin* | *bsd)
+    export PING_TIMEOUT_FLAG=t
+    ;;
+  *)
+    export PING_TIMEOUT_FLAG=w
+    ;;
+esac
 connect_test() {
   if [ -z "$EMAIL_CONN_TEST" ] || \
      [ "$EMAIL_CONN_TEST" = 'p' ] ; then                       # use ping test (default)
@@ -270,13 +278,13 @@ connect_test() {
     # would ping -qnc2 -w4 be better ?
     # would ping -qnc1 -w10 or -w20 be better ?
     #ping -qnc1 -w4 debian.org >/dev/null 2>&1 || return 1
-    ping -qnc2 -w10 debian.org >/dev/null 2>&1 || return 1
+    ping -qnc2 -${PING_TIMEOUT_FLAG}10 debian.org >/dev/null 2>&1 || return 1
 
   elif [ "$EMAIL_CONN_TEST" = 'P' ] ; then                     # use quicker ping test
     # I personally think that including a DNS lookup
     # is a better connection test but some
     # have found the above test too slow
-    ping -qnc1 -w4 8.8.8.8 >/dev/null 2>&1 || return 1
+    ping -qnc1 -${PING_TIMEOUT_FLAG}4 8.8.8.8 >/dev/null 2>&1 || return 1
 
   elif [ "$EMAIL_CONN_TEST" = 'n' ] ; then                     # use netcat (nc) test
     # must, of course, have netcat (nc) installed

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -78,7 +78,16 @@ set -o errtrace -o errexit            -o pipefail
 # optionally debug output by supplying TRACE=1
 [[ "${TRACE:-0}" == "1" ]] && set -o xtrace
 
-shopt -s inherit_errexit 2>/dev/null || true
+bash_has_min_version() {
+    (( BASH_VERSINFO[0] >= $1 && BASH_VERSINFO[1] >= $2 ))
+}
+
+# see https://git.savannah.gnu.org/gitweb/?p=bash.git;a=blob;f=NEWS;hb=6794b5478f660256a1023712b5fc169196ed0a22#l654
+if bash_has_min_version 4 4 ; then
+    if [ "$POSIXLY_CORRECT" = "y" ]; then
+        shopt -s inherit_errexit 2>/dev/null
+    fi
+fi
 IFS=$' \n\t'
 PS4='+\t '
 

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -85,7 +85,7 @@ bash_has_min_version() {
 
 # see https://git.savannah.gnu.org/gitweb/?p=bash.git;a=blob;f=NEWS;hb=6794b5478f660256a1023712b5fc169196ed0a22#l654
 if bash_has_min_version 4 4 ; then
-    if [ "$POSIXLY_CORRECT" == "y" ]; then
+    if [ "$POSIXLY_CORRECT" = "y" ]; then
         shopt -s inherit_errexit 2>/dev/null
     fi
 fi

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -393,10 +393,22 @@ send_queued_mail() {   # <-- mail id
   fi                                                           # (but allow continuation)
 }
 
+is_queue_dir_empty() {
+    # - "shopt -p" is available as of bash 2.01.1
+    # - "trap ... RETURN" is available as of bash 2.05b
+    # - the return value of shopt must be ignored (the manual says:
+    #   "The return status when listing options is zero if all
+    #   optnames are enabled, non-zero otherwise.")
+    trap "$(shopt -p nullglob || true)" RETURN
+    shopt -s nullglob
+    files=( "$MSMTPQ_Q"/*.mail )
+    (( ${#files[@]} == 0 ))
+}
+
 ## run (flush) queue
 ##
 run_queue() {    # <- 'sm' mode      # run queue
-  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ]; then
+  if is_queue_dir_empty ; then
     [ -n "$1" ] || dsp '' 'mail queue is empty (nothing to send)' ''
     return
   fi
@@ -416,7 +428,7 @@ run_queue() {    # <- 'sm' mode      # run queue
 ## display queue contents
 ##
 display_queue() {      # <-- { 'purge' | 'send' } (op label) ; { 'rec' } (record array of mail ids)
-  if [ -z "$(ls -A "$MSMTPQ_Q"/*.mail 2>/dev/null)" ]; then
+  if is_queue_dir_empty ; then
     if [ -z "$1" ]; then
       dsp '' 'no mail in queue' ''
     else

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -79,7 +79,8 @@ set -o errtrace -o errexit            -o pipefail
 [[ "${TRACE:-0}" == "1" ]] && set -o xtrace
 
 bash_has_min_version() {
-    (( BASH_VERSINFO[0] >= $1 && BASH_VERSINFO[1] >= $2 ))
+    ((  ( BASH_VERSINFO[0] > $1 )
+        || ( BASH_VERSINFO[0] == $1  &&  BASH_VERSINFO[1] >= $2 ) ))
 }
 
 # see https://git.savannah.gnu.org/gitweb/?p=bash.git;a=blob;f=NEWS;hb=6794b5478f660256a1023712b5fc169196ed0a22#l654


### PR DESCRIPTION
The shopt builtin of the bash which ships with macOS does not support the inherit_errexit option. Hence make sure the statement in line 81 does not fail even if the shopt option is not available.

Similarly, as macOS is a 4.4BSD, and hence its ping's command line parameters are subtly different from Linux's. The connect_test() function must make sure to use the appropriate ones.

This PR also fixes issue #103.