### PR TITLE
tests: skip msmtpd-dependent tests if msmtpd is not built

### DIFF
--- a/tests/test-auth-plain.sh
+++ b/tests/test-auth-plain.sh
@@ -2,9 +2,15 @@
 
 set -e
 
+msmtpd=../src/msmtpd
+if [ ! -x $msmtpd ]; then
+	echo 'msmtpd is not built'
+	exit 77
+fi
+
 # Start an msmtpd with PLAIN authentication
 echo "Starting msmtpd"
-../src/msmtpd --interface=::1 --port=12345 --auth='testuser,echo testpassword' \
+$msmtpd --interface=::1 --port=12345 --auth='testuser,echo testpassword' \
 	--command='cat > out-auth-plain-mail.txt; echo > out-auth-plain-rcpt.txt' &
 MSMTPD_PID=$!
 trap "kill $MSMTPD_PID" EXIT

--- a/tests/test-header-handling.sh
+++ b/tests/test-header-handling.sh
@@ -2,9 +2,15 @@
 
 set -e
 
+msmtpd=../src/msmtpd
+if [ ! -x $msmtpd ]; then
+	echo 'msmtpd is not built'
+	exit 77
+fi
+
 # Start an msmtpd that dumps the mail and the recipient lists so we can check them
 echo "Starting msmtpd"
-../src/msmtpd --interface=::1 --port=12346 \
+$msmtpd --interface=::1 --port=12346 \
 	--command='cat > out-header-handling-mail.txt; echo > out-header-handling-rcpt.txt' &
 MSMTPD_PID=$!
 trap "kill $MSMTPD_PID" EXIT


### PR DESCRIPTION
FAIL: test-auth-plain.sh
FAIL: test-header-handling.sh

These fails happen if the project is build with --without-msmtpd configure option.

See also: https://bugs.gentoo.org/948087