### PR TITLE
msmtpq: Adds connection test option q to force msmtpq to queue

### DIFF
--- a/scripts/msmtpq/README.msmtpq
+++ b/scripts/msmtpq/README.msmtpq
@@ -148,6 +148,8 @@ set sendmail = "EMAIL_CONN_TEST=s /path/to/msmtpq"
                  #  may not be a serious consideration, however, on
                  #  single user workstations - e.g. on laptops -
                  #  or in embedded systems)
+set sendmail = "EMAIL_CONN_TEST=q /path/to/msmtpq"
+                 # forces to queue all emails
 
 set sendmail = "EMAIL_QUEUE_QUIET=t /path/to/msmtpq"
                  # use queue ; suppress messages and 'chatter'

--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -56,7 +56,7 @@
 ## ======================================================================================
 ##
 #EMAIL_CONN_NOTEST=y                 # deprecated ; use below var
-#EMAIL_CONN_TEST={x| |p|P|n|s}       # see settings above for EMAIL_CONN_TEST
+#EMAIL_CONN_TEST={x| |p|P|n|s|q}     # see settings above for EMAIL_CONN_TEST
 ## ======================================================================================
 
 ## two essential patches by Philipp Hartwig
@@ -316,6 +316,8 @@ connect_test() {
     # thank you to Brian Goose, on the list, for encouraging this
     exec 3<>/dev/udp/debian.org/80 || return 1                 # open socket on site ; use dns
     exec 3<&- ; exec 3>&-                                      # close socket
+  elif [ "$EMAIL_CONN_TEST" = 'q' ] ; then                     # Force it to queue
+    return 1
   fi
   return 0
 }


### PR DESCRIPTION
This adds an option to force `msmtpq` to queue, even if there's internet available.