### PR TITLE
Update notification checks for DBUS session address

### DIFF
--- a/scripts/msmtpq/msmtpq
+++ b/scripts/msmtpq/msmtpq
@@ -123,14 +123,14 @@ if [ -n "$NOTIFY_SEND_VERBOSE" ]; then
   NOTIFY_SEND=1
 fi
 
-if [ -z "$NOTIFY_SEND" ] && [ ! -t 0 ] && [ -n "$DISPLAY" ] && command -v notify-send >/dev/null 2>&1; then
+if [ -z "$NOTIFY_SEND" ] && [ ! -t 0 ] && [ -n "$DBUS_SESSION_BUS_ADDRESS" ] && command -v notify-send >/dev/null 2>&1; then
   NOTIFY_SEND=1
 fi
 
 if [ "$NOTIFY_SEND" = 1 ]; then
-  # if [ -z "$DISPLAY" ] || [ -z "$WAYLAND_DISPLAY" ]; then
-  #   err "NOTIFY_SEND=1 set but no display available!"
-  # fi
+  if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    err "NOTIFY_SEND=1 set but no DBUS sesion address available!"
+  fi
   if ! command -v notify-send >/dev/null 2>&1; then
     err "NOTIFY_SEND=1 set but notify-send unavailable!"
   fi


### PR DESCRIPTION
checking for DBUS is more reliable as there's no hard dependency on (WAYLAND_)DISPLAY