### PR TITLE
Fix Winsock type incompatibilities on modern MinGW-w64 (UCRT / GCC 16)

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -445,7 +445,7 @@ int net_connect(int fd, const struct sockaddr *serv_addr, socklen_t addrlen,
 
             /* test for success, set errno */
             optlen = sizeof(err);
-            if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &err, &optlen) < 0)
+            if (getsockopt(fd, SOL_SOCKET, SO_ERROR, (char *)&err, &optlen) < 0)
             {
                 return -1;
             }
@@ -490,8 +490,8 @@ void net_set_io_timeout(int socket, int seconds)
     if (seconds > 0)
     {
         milliseconds = seconds * 1000;
-        (void)setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, &milliseconds, sizeof(int));
-        (void)setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, &milliseconds, sizeof(int));
+        (void)setsockopt(socket, SOL_SOCKET, SO_RCVTIMEO, (const char *)&milliseconds, sizeof(int));
+        (void)setsockopt(socket, SOL_SOCKET, SO_SNDTIMEO, (const char *)&milliseconds, sizeof(int));
     }
 #else /* UNIX */
     struct timeval tv;


### PR DESCRIPTION
## Summary

This patch fixes compilation errors on modern Windows toolchains using MinGW-w64 (UCRT64) with recent GCC versions (e.g. GCC 16).

The issue occurs due to stricter type checking in Winsock APIs where `getsockopt()` and `setsockopt()` expect `char *` / `const char *` parameters, but the code passes `DWORD *` or `int *` types without explicit casting.

## Problem

On modern MinGW-w64 / UCRT environments, the following compilation errors occur:

* incompatible pointer types in `getsockopt`
* incompatible pointer types in `setsockopt`

These were previously accepted as implicit conversions in older GCC versions but are now treated as errors under stricter type checking.

## Fix

This patch adds explicit casts to match the Winsock API expectations:

* `DWORD *` → `(char *)`
* `int *` → `(const char *)`

No functional changes are introduced.

## Impact

* Fixes build failures on:

  * MSYS2 UCRT64
  * MinGW-w64 with GCC 14+
  * Windows builds using modern toolchains

* No impact on Linux builds

* No behavioral change in runtime logic

## Tested on

* Windows 10 / MSYS2 UCRT64
* GCC 16.1.0
* MinGW-w64 14.x headers

## Notes

This issue appears due to stricter type enforcement in newer GCC versions combined with Winsock API signatures on Windows.

The fix is minimal and scoped to Windows builds.

---
