### PR TITLE
Fix heap buffer overflow in RCPT TO command buffer growth

### DIFF
--- a/src/msmtpd.c
+++ b/src/msmtpd.c
@@ -540,7 +540,7 @@ int msmtpd_session(log_t* log,
                         free(cmd);
                         return 1;
                     }
-                    tmpcmd = realloc(cmd, cmd_blocks * CMD_MAX_BLOCKS);
+                    tmpcmd = realloc(cmd, cmd_blocks * CMD_BLOCK_SIZE);
                     if (!tmpcmd) {
                         fprintf(out, "554 %s\r\n", strerror(ENOMEM));
                         log_msg(log, log_error, "%s, session aborted", strerror(ENOMEM));


### PR DESCRIPTION
When msmtpd grows the command buffer to accommodate additional RCPT TO addresses, the `realloc()` call at `src/msmtpd.c:543` uses `CMD_MAX_BLOCKS` (16) instead of `CMD_BLOCK_SIZE` (4096) as the multiplier. This causes the allocation to shrink from 4096 bytes to 32 bytes while `cmd_index` remains near 4096, resulting in a heap buffer overflow when the next recipient address is copied. An SMTP peer can trigger this by sending enough valid RCPT TO addresses to exceed the initial command buffer.

An AddressSanitizer build confirms the overflow: a 32-byte allocation at line 543 and a write 4042 bytes past it at line 552.

The fix replaces `CMD_MAX_BLOCKS` with `CMD_BLOCK_SIZE` in the realloc call to match the allocation unit used by the capacity check and initial malloc.