### PR TITLE
Fix base64 build on FreeBSD

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -18,6 +18,7 @@
 #ifndef BASE64_H
 #define BASE64_H
 
+#include <stdbool.h>
 #include <stddef.h>
 typedef size_t idx_t;
 


### PR DESCRIPTION
On FreeBSD with clang 21 build fails with:

In file included from smtp.c:42:
./base64.h:45:8: error: unknown type name 'bool'
   45 | extern bool base64_decode_ctx (struct base64_decode_context *ctx,
      |        ^

This happens because commit 4d710b4f8d09c3879bd0582cb61372168898f413 removed 'include <stdbool.h>' from base64.h. Add it back to make it compile again.